### PR TITLE
Configure on server startup and check for settings

### DIFF
--- a/cloudinary.js
+++ b/cloudinary.js
@@ -18,7 +18,7 @@ if (Meteor.isClient) {
 		Tracker.autorun(function () {
 			var file = Cloudinary.collection.findOne();
 			if (file) {
-				progress(file.percent_uploaded);
+				progress(file.percent_uploaded || 0);
 			}
 		});
 	};

--- a/cloudinary.js
+++ b/cloudinary.js
@@ -5,6 +5,7 @@ if (Meteor.isClient) {
 
 		Cloudinary.upload(files, {
 			folder: Meteor.settings.public.cloudinary.folder,
+      fields: {}
 		}, function (error, result) {
 			if (error) {
 				failure(new Meteor.Error('rwatts:orionjs-cloudinary', i18n('filesystem.messages.errorUploading')));

--- a/cloudinary.js
+++ b/cloudinary.js
@@ -13,7 +13,7 @@ if (Meteor.isClient) {
 			}
 			Cloudinary.collection.remove({});
 		});
-		
+
 		Tracker.autorun(function () {
 			var file = Cloudinary.collection.findOne();
 			if (file) {
@@ -34,12 +34,15 @@ if (Meteor.isClient) {
 }
 
 if (Meteor.isServer) {
-	Cloudinary.config({
-		cloud_name: Meteor.settings.private.cloudinary.cloud_name,
-		api_key: Meteor.settings.private.cloudinary.api_key,
-		api_secret: Meteor.settings.private.cloudinary.api_secret
+	Meteor.startup(function() {
+		if (Meteor.settings.private && Meteor.settings.private.cloudinary) {
+			Cloudinary.config({
+				cloud_name: Meteor.settings.private.cloudinary.cloud_name,
+				api_key: Meteor.settings.private.cloudinary.api_key,
+				api_secret: Meteor.settings.private.cloudinary.api_secret
+			});
+		}
 	});
-
 }
 if (Meteor.isClient) {
 	let cloud_name = Meteor.settings.public.cloudinary.cloud_name;

--- a/cloudinary.js
+++ b/cloudinary.js
@@ -24,7 +24,7 @@ if (Meteor.isClient) {
 	};
 
 	orion.filesystem.providerRemove = function (file, success, failure) {
-		Cloudinary.delete(file.meta.publicId, function (error, result) {
+		Cloudinary.delete(file.meta.public_id, function (error, result) {
 			if (error) {
 				failure(new Meteor.Error('rwatts:orionjs-cloudinary', i18n('filesystem.messages.errorRemoving')));
 			} else {

--- a/package.js
+++ b/package.js
@@ -14,14 +14,14 @@ Package.onUse(function(api) {
 		'orionjs:core@1.6.0',
 		'orionjs:filesystem@1.6.0',
 		'orionjs:config@1.6.0',
-		'lepozepo:cloudinary@4.1.3',
+		'lepozepo:cloudinary@4.2.2',
 		'ecmascript'
 	]);
-	
+
 	api.addFiles([
 		'cloudinary.js'
 	]);
-	
+
 	api.mainModule("cloudinary.js", "client");
 	api.export(['orion', 'Cloudinary']);
 });


### PR DESCRIPTION
Hi

In my case I apply the settings a little later than normal (just before Meteor.startup), this pull request will let the server configuration happen on Meteor.startup and check if the settings exist before configuring.
